### PR TITLE
feat(protocol): schemas up front, latched badge, and server capabilities (0.8.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,20 @@ Changelog for package pj_ros_bridge
     topic (e.g. ``/tf_static``) immediately receive the retained last message
   - TLS (``wss://``): optional server-certificate TLS via OpenSSL
     (``tls``/``certfile``/``keyfile``, CMake option ``PJ_BRIDGE_TLS``)
+* Demand-driven client support (PlotJuggler 4 per-topic subscriptions):
+  - ``include_schemas`` opt-in on ``get_topics`` and ``subscribe_topic_updates``:
+    topic entries gain ``encoding``/``definition`` so clients can classify
+    topics BEFORE subscribing; per-topic schema failure keeps the topic
+    listed (name+type only)
+  - ``latched: true`` badge on ``get_topics`` / ``topics_changed`` entries
+    when discovery knows every publisher offers ``TRANSIENT_LOCAL``
+    (ROS2: live graph QoS query, no subscription needed); latched replay
+    after the subscribe response is now a documented protocol guarantee
+  - ``server`` object in ``get_topics`` responses: ``{name, version,
+    capabilities[]}`` — clients feature-detect by capability name;
+    ``protocol_version`` stays the only hard compatibility gate
 * All changes are additive; ``protocol_version`` remains ``1``
-* 231 unit tests passing (TSAN/ASAN clean)
+* 245 unit tests passing (TSAN/ASAN clean)
 
 0.1.0 (2026-02-11)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package pj_ros_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.7.0 (2026-07-06)
+0.8.0 (2026-07-07)
 ------------------
 * Foxglove-parity feature set, closing the gap with foxglove_bridge's
   topic-subscription features:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,8 @@ pj_bridge_fastdds --domains 0 1 --port 9090 --publish-rate 50 --session-timeout 
 
 See `docs/API.md` for full semantics of each option (topic whitelist matching rules,
 QoS depth heuristics, `topics_changed` notification, backpressure policy, latched
-replay, and TLS setup).
+replay and the `latched` badge, `include_schemas`, the `server`
+identity/capabilities object, and TLS setup).
 
 ## Important Design Decisions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.14)
 project(pj_bridge)
 
+# Single source of truth for the server version: package.xml. Exposed to the
+# code as PJ_BRIDGE_VERSION (the `server.version` field in get_topics).
+file(STRINGS package.xml _pj_bridge_version_line REGEX "<version>[^<]+</version>" LIMIT_COUNT 1)
+string(REGEX REPLACE ".*<version>([^<]+)</version>.*" "\\1" PJ_BRIDGE_VERSION "${_pj_bridge_version_line}")
+if(NOT PJ_BRIDGE_VERSION MATCHES "^[0-9]")
+  set(PJ_BRIDGE_VERSION "unknown")
+endif()
+add_compile_definitions(PJ_BRIDGE_VERSION="${PJ_BRIDGE_VERSION}")
+
 # Compiler settings
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ independently.
 - **QoS Depth Heuristics** (ROS2 only): KEEP_LAST subscription depth is derived from the discovered publishers' depths and clamped to a configurable `[min_qos_depth, max_qos_depth]` range
 - **Pushed Topic Advertisement** (opt-in): Clients can subscribe to a `topics_changed` notification instead of polling `get_topics`, at a configurable `topic_poll_interval`
 - **Slow-Client Backpressure**: A bounded, drop-oldest per-client send queue (`client_backlog_size`) keeps a lagging client from blocking the publish loop or growing an unbounded backlog, instead of disconnecting it
-- **Latched Topic Replay** (ROS2 only): New subscribers to a `TRANSIENT_LOCAL` topic (e.g. `/tf_static`) immediately receive the retained last message instead of waiting for the next publish
+- **Latched Topic Replay** (ROS2 only): New subscribers to a `TRANSIENT_LOCAL` topic (e.g. `/tf_static`) immediately receive the retained last message instead of waiting for the next publish; such topics are badged `latched: true` in `get_topics`
+- **Schemas Up Front** (opt-in): `get_topics`/`subscribe_topic_updates` accept `include_schemas` so demand-driven clients (PlotJuggler 4) can classify topics before subscribing
+- **Capability Discovery**: `get_topics` responses identify the server (`name`, `version`) and list its `capabilities`, so clients feature-detect additive protocol features by name — `protocol_version` remains the only hard compatibility gate
 - **TLS / `wss://`** (opt-in): Serve the WebSocket endpoint over TLS with a server certificate + private key (`tls`/`--certfile`+`--keyfile`); clients connect via `wss://` instead of `ws://`
 
 ## CI Status

--- a/app/include/pj_bridge/bridge_server.hpp
+++ b/app/include/pj_bridge/bridge_server.hpp
@@ -161,6 +161,15 @@ class BridgeServer {
   /// failure handling identical.
   bool extract_schema(const std::string& topic_name, std::string& schema_out, std::string& error_out) const;
 
+  /// Defensive optional-bool read: false unless @p key is present AND boolean
+  /// (nlohmann's value() would throw on a wrong-typed value). Shared by every
+  /// handler reading an opt-in flag off the wire.
+  static bool optional_bool(const nlohmann::json& request, const char* key);
+
+  /// Stamp `latched: true` on a topic-entry when the topic is transient-local;
+  /// leave the key absent otherwise. Shared by get_topics and topics_changed.
+  void attach_latched_badge(nlohmann::json& topic_entry, const std::string& topic_name) const;
+
   /// Add `encoding` + `definition` schema fields to a topic list entry when a
   /// client opts into up-front schemas (get_topics / topics_changed
   /// `include_schemas`). A per-topic extraction failure is swallowed: the

--- a/app/include/pj_bridge/bridge_server.hpp
+++ b/app/include/pj_bridge/bridge_server.hpp
@@ -151,6 +151,25 @@ class BridgeServer {
   void inject_response_fields(nlohmann::json& response, const nlohmann::json& request) const;
   void cleanup_session(const std::string& client_id);
 
+  /// Extract a topic's schema, turning get_schema()'s throw-on-failure
+  /// contract into a bool. On success @p schema_out holds the definition
+  /// (which may legitimately be empty, e.g. std_msgs/msg/Empty); on failure
+  /// returns false with the exception's message in @p error_out. The caller
+  /// decides what a failure means — the subscribe path fails that one
+  /// subscription, while the get_topics / topics_changed paths keep the topic
+  /// listed without schema fields. Shared to keep both paths' extraction and
+  /// failure handling identical.
+  bool extract_schema(const std::string& topic_name, std::string& schema_out, std::string& error_out) const;
+
+  /// Add `encoding` + `definition` schema fields to a topic list entry when a
+  /// client opts into up-front schemas (get_topics / topics_changed
+  /// `include_schemas`). A per-topic extraction failure is swallowed: the
+  /// entry is left as name+type only and a warning is logged, so one bad
+  /// schema never drops a topic from the list — the same principle the
+  /// subscribe path follows for the topic list. Uses the same `encoding` /
+  /// `definition` field names as the subscribe response.
+  void attach_schema_fields(nlohmann::json& topic_entry, const std::string& topic_name) const;
+
   /// Release one middleware subscription ref for @p topic_name. When the
   /// last ref is gone (subscription destroyed), also clears the topic's
   /// latched state in the message buffer: a stale retained sample must not

--- a/app/include/pj_bridge/protocol_constants.hpp
+++ b/app/include/pj_bridge/protocol_constants.hpp
@@ -39,4 +39,16 @@ inline constexpr const char* kSchemaEncodingRos2Msg = "ros2msg";
 /// Schema encoding identifier for OMG IDL type definitions
 inline constexpr const char* kSchemaEncodingOmgIdl = "omgidl";
 
+/// Capability names advertised in the get_topics response's `server` object.
+/// Clients feature-detect by NAME (never by comparing version strings): a
+/// missing capability degrades that one feature with a warning, while a
+/// protocol_version above what the client speaks is the only hard-fail.
+inline constexpr const char* kServerCapabilities[] = {
+    "include_schemas",       // get_topics/subscribe_topic_updates opt-in schemas
+    "latched_badge",         // `latched: true` on transient-local topic entries
+    "latched_replay",        // retained samples replayed after subscribe/resume
+    "topics_changed",        // pushed topic advertisement (subscribe_topic_updates)
+    "per_topic_rate_limit",  // subscribe entries accept {name, max_rate_hz}
+};
+
 }  // namespace pj_bridge

--- a/app/include/pj_bridge/session_manager.hpp
+++ b/app/include/pj_bridge/session_manager.hpp
@@ -42,6 +42,12 @@ struct Session {
   /// True if this session opted in to server-initiated `topics_changed`
   /// notifications via the `subscribe_topic_updates` command.
   bool topic_updates{false};
+  /// True if this session's `topics_changed` notifications should carry
+  /// per-topic schemas (encoding+definition) on `added` entries — set via the
+  /// optional `include_schemas` flag on `subscribe_topic_updates`. Independent
+  /// of `topic_updates`: it only affects the shape of notifications, never
+  /// whether they are sent.
+  bool include_schemas_in_updates{false};
 };
 
 class SessionManager {
@@ -64,6 +70,8 @@ class SessionManager {
   bool is_paused(const std::string& client_id) const;
   bool set_topic_updates(const std::string& client_id, bool enabled);
   bool wants_topic_updates(const std::string& client_id) const;
+  bool set_include_schemas_in_updates(const std::string& client_id, bool enabled);
+  bool wants_schemas_in_updates(const std::string& client_id) const;
   bool set_ref_held(const std::string& client_id, const std::string& topic, bool held);
   std::unordered_set<std::string> get_ref_held_topics(const std::string& client_id) const;
 

--- a/app/include/pj_bridge/topic_source_interface.hpp
+++ b/app/include/pj_bridge/topic_source_interface.hpp
@@ -59,6 +59,17 @@ class TopicSourceInterface {
   /// Used in the subscribe response so clients know how to parse the schema.
   /// @return "ros2msg" for ROS2, "omgidl" for RTI DDS.
   virtual std::string schema_encoding() const = 0;
+
+  /// True when the DISCOVERY layer knows every publisher of `topic_name`
+  /// offers TRANSIENT_LOCAL durability — usable BEFORE any subscription
+  /// exists (unlike SubscriptionManagerInterface::is_transient_local, which is
+  /// only meaningful while subscribed). Drives the `latched: true` badge on
+  /// get_topics / topics_changed entries. Backends without discovery-time QoS
+  /// knowledge return false: the badge is then simply absent (absent = "not
+  /// latched or unknown"), never a false claim.
+  virtual bool is_transient_local(const std::string& /*topic_name*/) const {
+    return false;
+  }
 };
 
 }  // namespace pj_bridge

--- a/app/src/bridge_server.cpp
+++ b/app/src/bridge_server.cpp
@@ -257,6 +257,22 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
 
   json response;
   response["status"] = "success";
+  // Server identity + capability list: clients feature-detect by capability
+  // NAME and warn on missing features; `version` is for humans and bug
+  // reports, never for client-side comparison logic (docs/API.md). The only
+  // hard compatibility gate is protocol_version.
+  json server_info;
+  server_info["name"] = "pj_bridge";
+#ifdef PJ_BRIDGE_VERSION
+  server_info["version"] = PJ_BRIDGE_VERSION;
+#else
+  server_info["version"] = "unknown";
+#endif
+  server_info["capabilities"] = json::array();
+  for (const char* capability : kServerCapabilities) {
+    server_info["capabilities"].push_back(capability);
+  }
+  response["server"] = std::move(server_info);
   response["topics"] = json::array();
 
   size_t returned_count = 0;

--- a/app/src/bridge_server.cpp
+++ b/app/src/bridge_server.cpp
@@ -248,6 +248,13 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
 
   auto topics = topic_source_->get_topics();
 
+  // Opt-in: when the client sets `include_schemas`, each topic entry also
+  // carries `encoding` + `definition` so the client can classify topics
+  // up front without a subscribe round-trip. Absent/false leaves the response
+  // byte-for-byte as before.
+  const bool include_schemas = request.contains("include_schemas") && request["include_schemas"].is_boolean() &&
+                               request["include_schemas"].get<bool>();
+
   json response;
   response["status"] = "success";
   response["topics"] = json::array();
@@ -260,6 +267,9 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
     json topic_entry;
     topic_entry["name"] = topic.name;
     topic_entry["type"] = topic.type;
+    if (include_schemas) {
+      attach_schema_fields(topic_entry, topic.name);
+    }
     response["topics"].push_back(topic_entry);
     returned_count++;
   }
@@ -349,16 +359,16 @@ std::string BridgeServer::handle_subscribe(const std::string& client_id, const n
 
     std::string topic_type = topic_types[topic_name];
 
-    // get_schema throws on failure; an empty return is a legitimately empty
-    // definition (e.g. std_msgs/msg/Empty) and must not fail the subscribe.
+    // A schema failure fails only THIS subscription (the client can't decode a
+    // topic whose schema is missing); the topic list paths instead keep the
+    // topic without schema fields. Both share extract_schema().
     std::string schema;
-    try {
-      schema = topic_source_->get_schema(topic_name);
-    } catch (const std::exception& e) {
-      spdlog::error("Failed to get schema for topic '{}': {}", topic_name, e.what());
+    std::string schema_error;
+    if (!extract_schema(topic_name, schema, schema_error)) {
+      spdlog::error("Failed to get schema for topic '{}': {}", topic_name, schema_error);
       json failure;
       failure["topic"] = topic_name;
-      failure["reason"] = std::string("Schema extraction failed: ") + e.what();
+      failure["reason"] = "Schema extraction failed: " + schema_error;
       failures.push_back(failure);
       continue;
     }
@@ -658,7 +668,14 @@ std::string BridgeServer::handle_subscribe_topic_updates(const std::string& clie
   session_manager_->update_heartbeat(client_id);
   session_manager_->set_topic_updates(client_id, true);
 
-  spdlog::debug("Client '{}' subscribed to topic updates", client_id);
+  // Optional: opt into schemas (encoding+definition) on `topics_changed.added`
+  // entries. Always (re)set from the request so re-subscribing without the flag
+  // reverts to the name+type-only notification shape.
+  const bool include_schemas = request.contains("include_schemas") && request["include_schemas"].is_boolean() &&
+                               request["include_schemas"].get<bool>();
+  session_manager_->set_include_schemas_in_updates(client_id, include_schemas);
+
+  spdlog::debug("Client '{}' subscribed to topic updates (include_schemas={})", client_id, include_schemas);
 
   json response;
   response["status"] = "ok";
@@ -702,6 +719,33 @@ std::string BridgeServer::create_error_response(
   inject_response_fields(response, request);
 
   return response.dump();
+}
+
+bool BridgeServer::extract_schema(
+    const std::string& topic_name, std::string& schema_out, std::string& error_out) const {
+  // get_schema throws on failure; an empty return is a legitimately empty
+  // definition (e.g. std_msgs/msg/Empty) and is a success, not a failure.
+  try {
+    schema_out = topic_source_->get_schema(topic_name);
+    return true;
+  } catch (const std::exception& e) {
+    error_out = e.what();
+    return false;
+  }
+}
+
+void BridgeServer::attach_schema_fields(nlohmann::json& topic_entry, const std::string& topic_name) const {
+  std::string schema;
+  std::string error;
+  if (!extract_schema(topic_name, schema, error)) {
+    // Swallow the failure: a topic whose schema can't be extracted must still
+    // appear in the list (name+type only), matching the principle that schema
+    // failure can't corrupt the topic list.
+    spdlog::warn("Omitting schema for topic '{}' (extraction failed): {}", topic_name, error);
+    return;
+  }
+  topic_entry["encoding"] = topic_source_->schema_encoding();
+  topic_entry["definition"] = std::move(schema);
 }
 
 void BridgeServer::check_session_timeouts() {
@@ -766,21 +810,43 @@ void BridgeServer::check_topic_changes() {
     return;
   }
 
-  json notification;
-  notification["notification"] = "topics_changed";
-  notification["added"] = added;
-  notification["removed"] = removed;
-  notification["protocol_version"] = kProtocolVersion;
-
-  std::vector<uint8_t> bytes;
-  {
+  auto make_notification_bytes = [&](const json& added_entries) {
+    json notification;
+    notification["notification"] = "topics_changed";
+    notification["added"] = added_entries;
+    notification["removed"] = removed;
+    notification["protocol_version"] = kProtocolVersion;
     std::string text = notification.dump();
-    bytes.assign(text.begin(), text.end());
-  }
+    return std::vector<uint8_t>(text.begin(), text.end());
+  };
+
+  // Plain notification (name+type only) — today's shape, sent to sessions that
+  // opted in without `include_schemas`.
+  const std::vector<uint8_t> plain_bytes = make_notification_bytes(added);
+
+  // Schema-augmented variant: each `added` entry additionally carries
+  // encoding+definition (removed entries are unchanged). Built lazily on the
+  // first opted-in-with-schemas client so a deployment with none pays nothing;
+  // shared across all such clients so schemas are extracted once per poll.
+  std::optional<std::vector<uint8_t>> schema_bytes;
 
   for (const auto& client_id : session_manager_->get_active_sessions()) {
-    if (session_manager_->wants_topic_updates(client_id)) {
-      middleware_->send_reply(client_id, bytes);
+    if (!session_manager_->wants_topic_updates(client_id)) {
+      continue;
+    }
+    if (session_manager_->wants_schemas_in_updates(client_id)) {
+      if (!schema_bytes) {
+        json added_with_schemas = json::array();
+        for (const auto& entry : added) {
+          json augmented = entry;
+          attach_schema_fields(augmented, entry["name"].get<std::string>());
+          added_with_schemas.push_back(std::move(augmented));
+        }
+        schema_bytes = make_notification_bytes(added_with_schemas);
+      }
+      middleware_->send_reply(client_id, *schema_bytes);
+    } else {
+      middleware_->send_reply(client_id, plain_bytes);
     }
   }
 }

--- a/app/src/bridge_server.cpp
+++ b/app/src/bridge_server.cpp
@@ -252,8 +252,7 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
   // carries `encoding` + `definition` so the client can classify topics
   // up front without a subscribe round-trip. Absent/false leaves the response
   // byte-for-byte as before.
-  const bool include_schemas = request.contains("include_schemas") && request["include_schemas"].is_boolean() &&
-                               request["include_schemas"].get<bool>();
+  const bool include_schemas = optional_bool(request, "include_schemas");
 
   json response;
   response["status"] = "success";
@@ -263,11 +262,7 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
   // hard compatibility gate is protocol_version.
   json server_info;
   server_info["name"] = "pj_bridge";
-#ifdef PJ_BRIDGE_VERSION
   server_info["version"] = PJ_BRIDGE_VERSION;
-#else
-  server_info["version"] = "unknown";
-#endif
   server_info["capabilities"] = json::array();
   for (const char* capability : kServerCapabilities) {
     server_info["capabilities"].push_back(capability);
@@ -283,14 +278,7 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
     json topic_entry;
     topic_entry["name"] = topic.name;
     topic_entry["type"] = topic.type;
-    // `latched: true` only when discovery KNOWS the topic is transient-local
-    // (its retained sample is replayed on subscribe — see docs/API.md).
-    // Absent otherwise: backends without discovery-time QoS knowledge must
-    // not claim false. Independent of include_schemas — a UI badge should not
-    // require pulling every schema.
-    if (topic_source_->is_transient_local(topic.name)) {
-      topic_entry["latched"] = true;
-    }
+    attach_latched_badge(topic_entry, topic.name);
     if (include_schemas) {
       attach_schema_fields(topic_entry, topic.name);
     }
@@ -695,8 +683,7 @@ std::string BridgeServer::handle_subscribe_topic_updates(const std::string& clie
   // Optional: opt into schemas (encoding+definition) on `topics_changed.added`
   // entries. Always (re)set from the request so re-subscribing without the flag
   // reverts to the name+type-only notification shape.
-  const bool include_schemas = request.contains("include_schemas") && request["include_schemas"].is_boolean() &&
-                               request["include_schemas"].get<bool>();
+  const bool include_schemas = optional_bool(request, "include_schemas");
   session_manager_->set_include_schemas_in_updates(client_id, include_schemas);
 
   spdlog::debug("Client '{}' subscribed to topic updates (include_schemas={})", client_id, include_schemas);
@@ -758,6 +745,24 @@ bool BridgeServer::extract_schema(
   }
 }
 
+bool BridgeServer::optional_bool(const nlohmann::json& request, const char* key) {
+  // request.value(key, false) would THROW on a present-but-wrong-typed value;
+  // an off-the-wire flag must degrade to false instead.
+  const auto it = request.find(key);
+  return it != request.end() && it->is_boolean() && it->get<bool>();
+}
+
+void BridgeServer::attach_latched_badge(nlohmann::json& topic_entry, const std::string& topic_name) const {
+  // `latched: true` only when discovery KNOWS the topic is transient-local
+  // (its retained sample is replayed on subscribe — see docs/API.md). Absent
+  // otherwise: backends without discovery-time QoS knowledge must not claim
+  // false. Independent of include_schemas — a UI badge should not require
+  // pulling every schema.
+  if (topic_source_->is_transient_local(topic_name)) {
+    topic_entry["latched"] = true;
+  }
+}
+
 void BridgeServer::attach_schema_fields(nlohmann::json& topic_entry, const std::string& topic_name) const {
   std::string schema;
   std::string error;
@@ -816,9 +821,7 @@ void BridgeServer::check_topic_changes() {
         json entry;
         entry["name"] = name;
         entry["type"] = type;
-        if (topic_source_->is_transient_local(name)) {
-          entry["latched"] = true;  // same badge as get_topics
-        }
+        attach_latched_badge(entry, name);
         added.push_back(entry);
       }
     }

--- a/app/src/bridge_server.cpp
+++ b/app/src/bridge_server.cpp
@@ -267,6 +267,14 @@ std::string BridgeServer::handle_get_topics(const std::string& client_id, const 
     json topic_entry;
     topic_entry["name"] = topic.name;
     topic_entry["type"] = topic.type;
+    // `latched: true` only when discovery KNOWS the topic is transient-local
+    // (its retained sample is replayed on subscribe — see docs/API.md).
+    // Absent otherwise: backends without discovery-time QoS knowledge must
+    // not claim false. Independent of include_schemas — a UI badge should not
+    // require pulling every schema.
+    if (topic_source_->is_transient_local(topic.name)) {
+      topic_entry["latched"] = true;
+    }
     if (include_schemas) {
       attach_schema_fields(topic_entry, topic.name);
     }
@@ -792,6 +800,9 @@ void BridgeServer::check_topic_changes() {
         json entry;
         entry["name"] = name;
         entry["type"] = type;
+        if (topic_source_->is_transient_local(name)) {
+          entry["latched"] = true;  // same badge as get_topics
+        }
         added.push_back(entry);
       }
     }

--- a/app/src/session_manager.cpp
+++ b/app/src/session_manager.cpp
@@ -245,4 +245,27 @@ bool SessionManager::wants_topic_updates(const std::string& client_id) const {
   return it->second.topic_updates;
 }
 
+bool SessionManager::set_include_schemas_in_updates(const std::string& client_id, bool enabled) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(client_id);
+  if (it == sessions_.end()) {
+    return false;
+  }
+
+  it->second.include_schemas_in_updates = enabled;
+  return true;
+}
+
+bool SessionManager::wants_schemas_in_updates(const std::string& client_id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = sessions_.find(client_id);
+  if (it == sessions_.end()) {
+    return false;
+  }
+
+  return it->second.include_schemas_in_updates;
+}
+
 }  // namespace pj_bridge

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.6.0"
+  version: "0.8.0"
 
 package:
   name: pj-bridge-ros2-${{ ros_distro }}

--- a/docs/API.md
+++ b/docs/API.md
@@ -97,7 +97,7 @@ fully match any whitelist pattern are omitted from the response entirely (see
 Every `get_topics` response carries a `server` object:
 
 ```json
-{"server": {"name": "pj_bridge", "version": "0.6.0",
+{"server": {"name": "pj_bridge", "version": "0.8.0",
             "capabilities": ["include_schemas", "latched_badge",
                              "latched_replay", "topics_changed",
                              "per_topic_rate_limit"]}}

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,6 +92,43 @@ fully match any whitelist pattern are omitted from the response entirely (see
 }
 ```
 
+### Requesting schemas up front (`include_schemas`)
+
+By default `get_topics` returns only `name` + `type` per topic; schemas are
+delivered lazily on `subscribe`. A client that needs to classify topics before
+subscribing (e.g. by message type *and* schema) can set the optional
+`include_schemas` boolean to `true`:
+
+```json
+{"command": "get_topics", "id": "gt1", "include_schemas": true}
+```
+
+Each topic entry then additionally carries the same `encoding` and
+`definition` fields the [subscribe](#subscribe) response uses for schemas:
+
+```json
+{
+  "status": "success",
+  "id": "gt1",
+  "protocol_version": 1,
+  "topics": [
+    {"name": "/topic_name", "type": "package_name/msg/MessageType",
+     "encoding": "ros2msg", "definition": "message definition text"}
+  ]
+}
+```
+
+- `encoding` is the backend's schema encoding (`"ros2msg"` for ROS2,
+  `"omgidl"` for DDS).
+- The flag is purely additive: omitting it (or setting it to `false`) yields
+  the byte-for-byte name+type-only response above, so old and new clients
+  interoperate with old and new servers without a protocol bump.
+- **Per-topic schema failure never drops a topic.** If a topic's schema cannot
+  be extracted, that entry is still listed with `name` + `type` only (no
+  `encoding`/`definition`); the server logs a warning and continues. Clients
+  must therefore treat the schema fields as optional even when they asked for
+  them.
+
 ## Topic Whitelist
 
 The server can be configured with a list of regex patterns restricting which
@@ -318,6 +355,21 @@ topic set changes, instead of polling `get_topics`.
 {"status": "ok", "id": "tu1", "protocol_version": 1, "topic_updates": true}
 ```
 
+The request accepts the same optional `include_schemas` boolean as
+[`get_topics`](#requesting-schemas-up-front-include_schemas). When set to
+`true`, this session's `topics_changed` notifications carry per-topic schemas
+on their `added` entries (see below):
+
+```json
+{"command": "subscribe_topic_updates", "id": "tu1", "include_schemas": true}
+```
+
+The flag is stored per session and always taken from the latest
+`subscribe_topic_updates` request, so re-subscribing without it reverts to the
+name+type-only notification shape. It is independent of `topic_updates`
+itself — it only changes the shape of notifications, never whether they are
+sent.
+
 **Unsubscribe Request:**
 ```json
 {"command": "unsubscribe_topic_updates", "id": "tu2"}
@@ -343,10 +395,27 @@ changed since the last poll:
  "protocol_version": 1}
 ```
 
+For sessions that opted in with `include_schemas: true`, each `added` entry
+additionally carries `encoding` + `definition` (the same fields as
+[`get_topics`](#requesting-schemas-up-front-include_schemas) /
+[subscribe](#subscribe)); `removed` entries are unchanged (bare names):
+
+```json
+{"notification": "topics_changed",
+ "added": [{"name": "/t", "type": "pkg/msg/T",
+            "encoding": "ros2msg", "definition": "message definition text"}],
+ "removed": ["/gone"],
+ "protocol_version": 1}
+```
+
 - `added` and `removed` may each be empty, but a notification is only sent
   when at least one of them is non-empty.
 - A topic whose type changes (same name, different type) is reported as both
   removed and added.
+- **Per-topic schema failure never drops a topic** (same as `get_topics`): an
+  `added` entry whose schema cannot be extracted is delivered with `name` +
+  `type` only, no `encoding`/`definition`. Clients must treat the schema
+  fields as optional even when they opted in.
 - Only whitelisted topics (see [Topic Whitelist](#topic-whitelist)) are
   considered — a non-whitelisted topic appearing or disappearing never
   triggers a notification.

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,6 +92,29 @@ fully match any whitelist pattern are omitted from the response entirely (see
 }
 ```
 
+### Server identity and capabilities (`server`)
+
+Every `get_topics` response carries a `server` object:
+
+```json
+{"server": {"name": "pj_bridge", "version": "0.6.0",
+            "capabilities": ["include_schemas", "latched_badge",
+                             "latched_replay", "topics_changed",
+                             "per_topic_rate_limit"]}}
+```
+
+Compatibility policy for clients:
+
+- **`protocol_version` is the only hard gate.** A client that receives a
+  `protocol_version` above what it speaks should stop and tell the user to
+  upgrade (breaking changes bump it; additive changes never do).
+- **Feature-detect by capability NAME, never by comparing `version`.** A
+  missing capability degrades that one feature (ideally with a precise
+  warning, e.g. "no `include_schemas`: topic classification degraded").
+  `version` is for humans and bug reports.
+- A response without a `server` object is a pre-capability server: treat
+  every capability above as absent.
+
 ### Requesting schemas up front (`include_schemas`)
 
 By default `get_topics` returns only `name` + `type` per topic; schemas are

--- a/docs/API.md
+++ b/docs/API.md
@@ -129,6 +129,34 @@ Each topic entry then additionally carries the same `encoding` and
   must therefore treat the schema fields as optional even when they asked for
   them.
 
+### Latched (transient-local) topics
+
+Some topics publish a retained sample that late subscribers depend on —
+`/tf_static` (typically ONE message per session, carrying the robot's static
+geometry), `/map`, and similar. Two protocol guarantees make these safe under
+per-topic, subscribe-on-demand clients, where **every** subscriber is a late
+subscriber by construction:
+
+1. **Latched replay (server MUST).** Immediately after a `subscribe` (or
+   `resume`) response that adds a transient-local topic, and before any live
+   data for it, the server sends the topic's retained sample(s) as a normal
+   binary data frame. The reply ordering matters: the response carries the
+   schema, so the client can always decode the replayed frame.
+2. **The `latched` badge (server SHOULD).** When the server *knows* a topic is
+   transient-local — the ROS2 backend queries the discovered publishers'
+   durability QoS, without subscribing — the topic's entry in `get_topics`
+   responses and `topics_changed.added` carries `"latched": true`:
+
+```json
+{"name": "/tf_static", "type": "tf2_msgs/msg/TFMessage", "latched": true}
+```
+
+   The key is **absent** otherwise: absent means "not latched, or unknown" —
+   backends without discovery-time QoS knowledge stay silent rather than
+   claiming `false`. The badge is independent of `include_schemas` and is
+   informational (UI, diagnostics); correctness relies only on guarantee 1.
+   As everywhere in this protocol, clients must ignore unknown fields.
+
 ## Topic Whitelist
 
 The server can be configured with a list of regex patterns restricting which
@@ -394,6 +422,9 @@ changed since the last poll:
  "removed": ["/gone"],
  "protocol_version": 1}
 ```
+
+`added` entries carry the same optional `"latched": true` badge as
+[`get_topics`](#latched-transient-local-topics) entries.
 
 For sessions that opted in with `include_schemas: true`, each `added` entry
 additionally carries `encoding` + `definition` (the same fields as

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,13 @@ Three interfaces decouple the core from any specific middleware:
 
 ### TopicSourceInterface
 
-Discovers available topics and retrieves their schemas. Implementations:
+Discovers available topics, retrieves their schemas, and reports
+discovery-time QoS knowledge: `is_transient_local()` answers "does every
+discovered publisher offer TRANSIENT_LOCAL?" WITHOUT subscribing (the
+SubscriptionManager's same-named flag is only valid while subscribed, which
+is useless for badging unsubscribed topics under lazy demand). Backends
+without discovery-time QoS knowledge keep the default `false`, so the
+`latched` badge is simply absent rather than falsely claimed. Implementations:
 - `Ros2TopicSource`: wraps `TopicDiscovery` (rclcpp enumeration) + `SchemaExtractor` (.msg file parsing). Schema encoding: `"ros2msg"`.
 - `RtiTopicSource`: wraps `DdsTopicDiscovery` (RTI participant discovery). Schema encoding: `"omgidl"`.
 - `FastDdsTopicSource`: directly implements the interface (flattened design). Discovers topics via `on_data_writer_discovery()`, resolves `DynamicType` from TypeObject registry, generates IDL via `idl_serialize()`. Schema encoding: `"omgidl"`.

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pj_bridge</name>
-  <version>0.6.0</version>
+  <version>0.8.0</version>
   <description>Multi-backend bridge server (ROS2 / RTI DDS) that forwards topic content over WebSocket</description>
   <maintainer email="davide.faconti@gmail.com">davide</maintainer>
   <author email="davide.faconti@gmail.com">davide</author>

--- a/ros2/include/pj_bridge_ros2/ros2_topic_source.hpp
+++ b/ros2/include/pj_bridge_ros2/ros2_topic_source.hpp
@@ -45,6 +45,7 @@ class Ros2TopicSource : public TopicSourceInterface {
   std::vector<TopicInfo> get_topics() override;
   std::string get_schema(const std::string& topic_name) override;
   std::string schema_encoding() const override;
+  bool is_transient_local(const std::string& topic_name) const override;
 
  private:
   TopicDiscovery topic_discovery_;

--- a/ros2/include/pj_bridge_ros2/topic_discovery.hpp
+++ b/ros2/include/pj_bridge_ros2/topic_discovery.hpp
@@ -45,6 +45,15 @@ class TopicDiscovery {
    */
   std::vector<TopicInfo> discover_topics();
 
+  /**
+   * @brief Whether every discovered publisher of the topic offers
+   * TRANSIENT_LOCAL durability (the same rule the subscription manager's
+   * adapt_qos applies at subscribe time, evaluated here WITHOUT subscribing —
+   * a live graph query, so it works for topics no client has requested yet).
+   * False when the topic has no publishers.
+   */
+  bool is_transient_local(const std::string& topic_name) const;
+
  private:
   rclcpp::Node::SharedPtr node_;
 

--- a/ros2/src/ros2_topic_source.cpp
+++ b/ros2/src/ros2_topic_source.cpp
@@ -58,4 +58,8 @@ std::string Ros2TopicSource::schema_encoding() const {
   return kSchemaEncodingRos2Msg;
 }
 
+bool Ros2TopicSource::is_transient_local(const std::string& topic_name) const {
+  return topic_discovery_.is_transient_local(topic_name);
+}
+
 }  // namespace pj_bridge

--- a/ros2/src/topic_discovery.cpp
+++ b/ros2/src/topic_discovery.cpp
@@ -43,6 +43,19 @@ std::vector<TopicInfo> TopicDiscovery::discover_topics() {
   return topics;
 }
 
+bool TopicDiscovery::is_transient_local(const std::string& topic_name) const {
+  const auto publishers = node_->get_publishers_info_by_topic(topic_name);
+  if (publishers.empty()) {
+    return false;
+  }
+  for (const auto& info : publishers) {
+    if (info.qos_profile().durability() != rclcpp::DurabilityPolicy::TransientLocal) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool TopicDiscovery::should_filter_topic(const std::string& topic_name) const {
   static const std::vector<std::string> kSystemTopics = {"/rosout", "/parameter_events", "/robot_description"};
 

--- a/tests/unit/test_bridge_server.cpp
+++ b/tests/unit/test_bridge_server.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -245,6 +246,9 @@ class MockTopicSource : public TopicSourceInterface {
   }
 
   std::string get_schema(const std::string& topic_name) override {
+    if (throwing_schema_topics_.count(topic_name) > 0) {
+      throw std::runtime_error("simulated schema extraction failure");
+    }
     if (empty_schema_topics_.count(topic_name) > 0) {
       return "";  // legitimately empty definition (e.g. std_msgs/msg/Empty)
     }
@@ -277,9 +281,16 @@ class MockTopicSource : public TopicSourceInterface {
     empty_schema_topics_.insert(name);
   }
 
+  // Test helper: mark a topic whose get_schema() throws (simulating a backend
+  // schema-extraction failure).
+  void set_throwing_schema_topic(const std::string& name) {
+    throwing_schema_topics_.insert(name);
+  }
+
  private:
   std::vector<TopicInfo> topics_;
   std::unordered_set<std::string> empty_schema_topics_;
+  std::unordered_set<std::string> throwing_schema_topics_;
 };
 
 // ---------------------------------------------------------------------------
@@ -494,6 +505,119 @@ TEST_F(BridgeServerTest, HandleGetTopics) {
   EXPECT_EQ(reply["status"], "success");
   EXPECT_TRUE(reply.contains("topics"));
   EXPECT_TRUE(reply["topics"].is_array());
+}
+
+// ---------------------------------------------------------------------------
+// GetTopicsWithSchemasIncludesDefinitions
+//
+// When the client opts in with `include_schemas: true`, every topic entry
+// additionally carries `encoding` (schema_encoding()) and `definition`
+// (get_schema()) — the same field vocabulary the subscribe response uses.
+// ---------------------------------------------------------------------------
+TEST_F(BridgeServerTest, GetTopicsWithSchemasIncludesDefinitions) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/imu", "sensor_msgs/msg/Imu"}, {"/img", "sensor_msgs/msg/Image"}});
+
+  json req;
+  req["command"] = "get_topics";
+  req["include_schemas"] = true;
+  mock_->push_request("client_gs", req.dump());
+  server_->process_requests();
+
+  json reply = mock_->pop_reply("client_gs");
+  ASSERT_FALSE(reply.is_discarded());
+  EXPECT_EQ(reply["status"], "success");
+  ASSERT_TRUE(reply["topics"].is_array());
+  ASSERT_EQ(reply["topics"].size(), 2u);
+
+  for (const auto& entry : reply["topics"]) {
+    ASSERT_TRUE(entry.contains("name"));
+    ASSERT_TRUE(entry.contains("type"));
+    ASSERT_TRUE(entry.contains("encoding")) << "topic " << entry["name"] << " missing encoding";
+    ASSERT_TRUE(entry.contains("definition")) << "topic " << entry["name"] << " missing definition";
+    EXPECT_EQ(entry["encoding"], "ros2msg");
+    EXPECT_EQ(entry["definition"], "uint32 seq\nstring data\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GetTopicsWithoutSchemasHasNoSchemaFields  (regression pin)
+//
+// Absent (or false) `include_schemas` must yield today's byte-for-byte
+// behavior: name+type only, no schema fields.
+// ---------------------------------------------------------------------------
+TEST_F(BridgeServerTest, GetTopicsWithoutSchemasHasNoSchemaFields) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/imu", "sensor_msgs/msg/Imu"}});
+
+  // No include_schemas field at all.
+  json req;
+  req["command"] = "get_topics";
+  mock_->push_request("client_ns", req.dump());
+  server_->process_requests();
+
+  json reply = mock_->pop_reply("client_ns");
+  ASSERT_FALSE(reply.is_discarded());
+  ASSERT_EQ(reply["topics"].size(), 1u);
+  EXPECT_EQ(reply["topics"][0]["name"], "/imu");
+  EXPECT_EQ(reply["topics"][0]["type"], "sensor_msgs/msg/Imu");
+  EXPECT_FALSE(reply["topics"][0].contains("encoding"));
+  EXPECT_FALSE(reply["topics"][0].contains("definition"));
+
+  // Explicit include_schemas: false behaves identically.
+  json req_false;
+  req_false["command"] = "get_topics";
+  req_false["include_schemas"] = false;
+  mock_->push_request("client_ns", req_false.dump());
+  server_->process_requests();
+
+  json reply_false = mock_->pop_reply("client_ns");
+  ASSERT_FALSE(reply_false.is_discarded());
+  ASSERT_EQ(reply_false["topics"].size(), 1u);
+  EXPECT_FALSE(reply_false["topics"][0].contains("encoding"));
+  EXPECT_FALSE(reply_false["topics"][0].contains("definition"));
+}
+
+// ---------------------------------------------------------------------------
+// GetTopicsSchemaFailureStillListsTopic
+//
+// A per-topic schema-extraction failure must not fail or drop anything: the
+// offending topic is still listed (name+type only, no schema fields), and
+// other topics still carry their schemas.
+// ---------------------------------------------------------------------------
+TEST_F(BridgeServerTest, GetTopicsSchemaFailureStillListsTopic) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/good", "std_msgs/msg/String"}, {"/bad", "std_msgs/msg/String"}});
+  mock_topic_source_->set_throwing_schema_topic("/bad");
+
+  json req;
+  req["command"] = "get_topics";
+  req["include_schemas"] = true;
+  mock_->push_request("client_sf", req.dump());
+  server_->process_requests();
+
+  json reply = mock_->pop_reply("client_sf");
+  ASSERT_FALSE(reply.is_discarded());
+  EXPECT_EQ(reply["status"], "success");
+  ASSERT_EQ(reply["topics"].size(), 2u);
+
+  // Both topics present; only the failing one lacks schema fields.
+  bool saw_good = false;
+  bool saw_bad = false;
+  for (const auto& entry : reply["topics"]) {
+    if (entry["name"] == "/good") {
+      saw_good = true;
+      EXPECT_TRUE(entry.contains("encoding"));
+      EXPECT_TRUE(entry.contains("definition"));
+    } else if (entry["name"] == "/bad") {
+      saw_bad = true;
+      EXPECT_EQ(entry["type"], "std_msgs/msg/String");
+      EXPECT_FALSE(entry.contains("encoding"));
+      EXPECT_FALSE(entry.contains("definition"));
+    }
+  }
+  EXPECT_TRUE(saw_good);
+  EXPECT_TRUE(saw_bad);
 }
 
 // ---------------------------------------------------------------------------
@@ -2504,6 +2628,69 @@ TEST_F(BridgeServerTest, UnsubscribeTopicUpdatesStopsNotifications) {
 
   auto replies = mock_->get_replies("client_x");
   EXPECT_TRUE(replies.empty());
+}
+
+// TopicsChangedIncludesSchemasWhenClientOptedIn
+//
+// A session that opts into topic updates WITH include_schemas:true receives
+// schema fields (encoding+definition) on each `added` entry; removed entries
+// stay unchanged (bare names).
+TEST_F(BridgeServerTest, TopicsChangedIncludesSchemasWhenClientOptedIn) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}});
+
+  json sub;
+  sub["command"] = "subscribe_topic_updates";
+  sub["include_schemas"] = true;
+  mock_->push_request("client_schema_updates", sub.dump());
+  server_->process_requests();
+
+  server_->check_topic_changes();  // first call: snapshot only
+  mock_->clear_replies();
+
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}, {"/b", "sensor_msgs/msg/Imu"}});
+  server_->check_topic_changes();
+
+  auto replies = mock_->get_replies("client_schema_updates");
+  ASSERT_EQ(replies.size(), 1u);
+  json notif = replies[0];
+  EXPECT_EQ(notif["notification"], "topics_changed");
+  ASSERT_EQ(notif["added"].size(), 1u);
+  EXPECT_EQ(notif["added"][0]["name"], "/b");
+  EXPECT_EQ(notif["added"][0]["type"], "sensor_msgs/msg/Imu");
+  ASSERT_TRUE(notif["added"][0].contains("encoding"));
+  ASSERT_TRUE(notif["added"][0].contains("definition"));
+  EXPECT_EQ(notif["added"][0]["encoding"], "ros2msg");
+  EXPECT_EQ(notif["added"][0]["definition"], "uint32 seq\nstring data\n");
+}
+
+// TopicsChangedOmitsSchemasWhenClientDidNotOptIn
+//
+// A session opted into topic updates WITHOUT include_schemas gets today's
+// name+type-only `added` entries — no schema fields.
+TEST_F(BridgeServerTest, TopicsChangedOmitsSchemasWhenClientDidNotOptIn) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}});
+
+  json sub;
+  sub["command"] = "subscribe_topic_updates";  // no include_schemas flag
+  mock_->push_request("client_plain_updates", sub.dump());
+  server_->process_requests();
+
+  server_->check_topic_changes();  // snapshot
+  mock_->clear_replies();
+
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}, {"/b", "sensor_msgs/msg/Imu"}});
+  server_->check_topic_changes();
+
+  auto replies = mock_->get_replies("client_plain_updates");
+  ASSERT_EQ(replies.size(), 1u);
+  json notif = replies[0];
+  ASSERT_EQ(notif["added"].size(), 1u);
+  EXPECT_EQ(notif["added"][0]["name"], "/b");
+  EXPECT_EQ(notif["added"][0]["type"], "sensor_msgs/msg/Imu");
+  EXPECT_FALSE(notif["added"][0].contains("encoding"));
+  EXPECT_FALSE(notif["added"][0].contains("definition"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/test_bridge_server.cpp
+++ b/tests/unit/test_bridge_server.cpp
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+#include <set>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -245,6 +246,16 @@ class MockTopicSource : public TopicSourceInterface {
     return topics_;
   }
 
+  bool is_transient_local(const std::string& topic_name) const override {
+    return latched_topics_.count(topic_name) > 0;
+  }
+
+  /// Mark a topic as known-transient-local at DISCOVERY time (get_topics /
+  /// topics_changed badge the entry `latched: true`).
+  void set_latched_topics(std::set<std::string> topics) {
+    latched_topics_ = std::move(topics);
+  }
+
   std::string get_schema(const std::string& topic_name) override {
     if (throwing_schema_topics_.count(topic_name) > 0) {
       throw std::runtime_error("simulated schema extraction failure");
@@ -289,6 +300,7 @@ class MockTopicSource : public TopicSourceInterface {
 
  private:
   std::vector<TopicInfo> topics_;
+  std::set<std::string> latched_topics_;
   std::unordered_set<std::string> empty_schema_topics_;
   std::unordered_set<std::string> throwing_schema_topics_;
 };
@@ -2635,6 +2647,67 @@ TEST_F(BridgeServerTest, UnsubscribeTopicUpdatesStopsNotifications) {
 // A session that opts into topic updates WITH include_schemas:true receives
 // schema fields (encoding+definition) on each `added` entry; removed entries
 // stay unchanged (bare names).
+// GetTopicsMarksLatchedTopics
+//
+// A topic the discovery layer knows is TRANSIENT_LOCAL carries `latched: true`
+// in its get_topics entry; all other topics carry NO `latched` key (absent =
+// not latched or unknown — backends without discovery-time QoS knowledge stay
+// silent rather than claiming false). Independent of include_schemas.
+TEST_F(BridgeServerTest, GetTopicsMarksLatchedTopics) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/tf_static", "tf2_msgs/msg/TFMessage"}, {"/imu", "sensor_msgs/msg/Imu"}});
+  mock_topic_source_->set_latched_topics({"/tf_static"});
+
+  for (const bool with_schemas : {false, true}) {
+    json req;
+    req["command"] = "get_topics";
+    if (with_schemas) {
+      req["include_schemas"] = true;
+    }
+    mock_->clear_replies();
+    mock_->push_request("client_latched", req.dump());
+    server_->process_requests();
+
+    auto replies = mock_->get_replies("client_latched");
+    ASSERT_EQ(replies.size(), 1u);
+    for (const auto& entry : replies[0]["topics"]) {
+      if (entry["name"] == "/tf_static") {
+        ASSERT_TRUE(entry.contains("latched")) << "with_schemas=" << with_schemas;
+        EXPECT_EQ(entry["latched"], true);
+      } else {
+        EXPECT_FALSE(entry.contains("latched")) << entry.dump();
+      }
+    }
+  }
+}
+
+// TopicsChangedAddedEntriesCarryLatched
+//
+// A late-appearing transient-local topic is badged in the topics_changed push
+// too, so a client that missed the initial get_topics still learns it.
+TEST_F(BridgeServerTest, TopicsChangedAddedEntriesCarryLatched) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}});
+
+  json sub;
+  sub["command"] = "subscribe_topic_updates";
+  mock_->push_request("client_latched_updates", sub.dump());
+  server_->process_requests();
+
+  server_->check_topic_changes();  // snapshot
+  mock_->clear_replies();
+
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}, {"/map", "nav_msgs/msg/OccupancyGrid"}});
+  mock_topic_source_->set_latched_topics({"/map"});
+  server_->check_topic_changes();
+
+  auto replies = mock_->get_replies("client_latched_updates");
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0]["added"].size(), 1u);
+  EXPECT_EQ(replies[0]["added"][0]["name"], "/map");
+  EXPECT_EQ(replies[0]["added"][0]["latched"], true);
+}
+
 TEST_F(BridgeServerTest, TopicsChangedIncludesSchemasWhenClientOptedIn) {
   ASSERT_TRUE(server_->initialize());
   mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}});

--- a/tests/unit/test_bridge_server.cpp
+++ b/tests/unit/test_bridge_server.cpp
@@ -2653,6 +2653,34 @@ TEST_F(BridgeServerTest, UnsubscribeTopicUpdatesStopsNotifications) {
 // in its get_topics entry; all other topics carry NO `latched` key (absent =
 // not latched or unknown — backends without discovery-time QoS knowledge stay
 // silent rather than claiming false). Independent of include_schemas.
+// GetTopicsCarriesServerInfo
+//
+// The get_topics response identifies the server and lists its capabilities so
+// clients can feature-detect by NAME (and warn precisely on missing features)
+// instead of comparing version strings. protocol_version remains the only
+// hard compatibility gate.
+TEST_F(BridgeServerTest, GetTopicsCarriesServerInfo) {
+  ASSERT_TRUE(server_->initialize());
+  mock_topic_source_->set_topics({{"/a", "std_msgs/msg/String"}});
+
+  json req;
+  req["command"] = "get_topics";
+  mock_->push_request("client_info", req.dump());
+  server_->process_requests();
+
+  auto replies = mock_->get_replies("client_info");
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_TRUE(replies[0].contains("server"));
+  const json& info = replies[0]["server"];
+  EXPECT_EQ(info["name"], "pj_bridge");
+  EXPECT_FALSE(info["version"].get<std::string>().empty());
+  ASSERT_TRUE(info["capabilities"].is_array());
+  const auto& caps = info["capabilities"];
+  for (const char* expected : {"include_schemas", "latched_badge", "latched_replay", "topics_changed"}) {
+    EXPECT_TRUE(std::find(caps.begin(), caps.end(), json(expected)) != caps.end()) << "missing " << expected;
+  }
+}
+
 TEST_F(BridgeServerTest, GetTopicsMarksLatchedTopics) {
   ASSERT_TRUE(server_->initialize());
   mock_topic_source_->set_topics({{"/tf_static", "tf2_msgs/msg/TFMessage"}, {"/imu", "sensor_msgs/msg/Imu"}});

--- a/tests/unit/test_session_manager.cpp
+++ b/tests/unit/test_session_manager.cpp
@@ -348,6 +348,30 @@ TEST_F(SessionManagerTest, WantsTopicUpdatesReturnsFalseForNonexistentSession) {
   EXPECT_FALSE(manager_.wants_topic_updates("nonexistent"));
 }
 
+TEST_F(SessionManagerTest, SessionStartsWithSchemasInUpdatesDisabled) {
+  EXPECT_TRUE(manager_.create_session("client1"));
+
+  EXPECT_FALSE(manager_.wants_schemas_in_updates("client1"));
+}
+
+TEST_F(SessionManagerTest, SetIncludeSchemasInUpdatesChangesState) {
+  EXPECT_TRUE(manager_.create_session("client1"));
+
+  EXPECT_TRUE(manager_.set_include_schemas_in_updates("client1", true));
+  EXPECT_TRUE(manager_.wants_schemas_in_updates("client1"));
+
+  EXPECT_TRUE(manager_.set_include_schemas_in_updates("client1", false));
+  EXPECT_FALSE(manager_.wants_schemas_in_updates("client1"));
+}
+
+TEST_F(SessionManagerTest, SetIncludeSchemasInUpdatesReturnsFalseForNonexistentSession) {
+  EXPECT_FALSE(manager_.set_include_schemas_in_updates("nonexistent", true));
+}
+
+TEST_F(SessionManagerTest, WantsSchemasInUpdatesReturnsFalseForNonexistentSession) {
+  EXPECT_FALSE(manager_.wants_schemas_in_updates("nonexistent"));
+}
+
 TEST_F(SessionManagerTest, ThreadSafety) {
   SessionManager thread_manager(10.0);
   constexpr int kNumThreads = 10;


### PR DESCRIPTION
## What & why

Extends the pj_bridge server protocol so PlotJuggler 4's **demand-driven per-topic subscriptions** work well against it — the client lists every advertised topic as a paused placeholder and only subscribes over the wire while a topic is displayed. That flow needs three things the server didn't expose, all strictly additive (**`protocol_version` stays `1`**; old clients and old servers interoperate unchanged).

Released as **0.8.0** (collapses the never-tagged 0.7.0 foxglove-parity entry).

## The three additions

1. **`include_schemas` on `get_topics` / `subscribe_topic_updates`** — opt-in per-topic `encoding` + `definition` (same vocabulary as the `subscribe` response) so a client can classify topics *before* subscribing. Per-topic schema-extraction failure never drops a topic: it's still listed name+type-only.
2. **`latched` badge + latched-replay contract** — transient-local topics (`/tf_static` & friends) publish one retained sample late subscribers depend on, and under demand subscriptions *every* subscriber is late. Latched replay after the subscribe response is now a **documented protocol guarantee** (the server already did it); `get_topics`/`topics_changed` entries carry `"latched": true` when discovery knows the topic is transient-local. Detection lives on the discovery side (`TopicSourceInterface::is_transient_local`; ROS2 queries publisher durability QoS without subscribing). Backends without the knowledge omit the key — absent means "not latched or unknown", never a false claim.
3. **`server` identity + capabilities object in `get_topics`** — `{name, version, capabilities: [...]}`. The compatibility policy, now explicit: **`protocol_version` is the only hard gate**; everything additive is feature-detected by capability *name*, never by comparing version strings (version algebra fails closed against backports, open against forks). `version` is single-sourced from `package.xml` at configure time.

## Testing

`245` unit tests (TSAN/ASAN clean). Every new behavior was added test-first (red before green): schema opt-in / default / per-topic-failure, the latched badge with and without `include_schemas`, and the server-info object. **Live-verified end-to-end** with a PlotJuggler 4 client against a 17 GB robot bag: placeholders → demand subscribe → TF resolves → pointclouds render.

## Companion PR

The PlotJuggler 4 client side (the `data_stream_pj_bridge` plugin that consumes all three features) is in **pj-official-plugins → `feat/pj-bridge-demand`**. The plugin degrades gracefully against a pre-0.8.0 server, so the two can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
